### PR TITLE
Fix 404 on skills and experience pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 _site/
 .jekyll-cache/
 Gemfile.lock
+build.log
+bundle.log

--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,7 @@ paginate: 5
 collections:
   pages:
     output: true
+    permalink: /:name/
 
 defaults:
   - scope:

--- a/_pages/experience.md
+++ b/_pages/experience.md
@@ -1,4 +1,3 @@
-
 ---
 title: "Experience"
 permalink: /experience/

--- a/_pages/skills.md
+++ b/_pages/skills.md
@@ -1,4 +1,3 @@
-
 ---
 title: "Skills"
 permalink: /skills/


### PR DESCRIPTION
## Summary
- configure collection pages to output to root paths
- remove leading blank line from skills.md and experience.md so Jekyll processes them
- ignore build.log and bundle.log

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6862e1cdbea0832fbd2b89dcc9ef4596