### PR TITLE
Improve about page color and hero

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -6,7 +6,7 @@ layout: single
 
 <div class="hero">
   <h1>About Me</h1>
-  <p>Hi, my name is <span style="color: #0072b1;">M&nbsp;N Pasima</span>, and I am a DevOps Engineer.</p>
+  <p>Hi, my name is <span style="color: #ffd700;">M&nbsp;N Pasima</span>, and I am a DevOps Engineer.</p>
 </div>
 
 Results-driven self-taught DevOps Engineer with 6+ years specializing in cloud-native automation, CI/CD pipelines, and infrastructure-as-code. Expert in AWS, GCP, Kubernetes (EKS, GKE), and Terraform/Terragrunt, delivering scalable, secure solutions. Proven track record: accelerated deployments by 80%, cut costs 30%, and maintained 99.99% uptime across multi-cloud environments.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -71,15 +71,16 @@ header img {
 
 /* Hero section */
 .hero {
-  /* Splash area with gradient background */
-  background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
+  /* Sleek gradient background */
+  background: linear-gradient(135deg, #232526 0%, #414345 100%);
   background-size: cover;
   background-position: center;
   color: white;
   padding: 120px 20px;
   margin: 40px 0;
   text-align: center;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
 }
 
 .hero h1 {


### PR DESCRIPTION
## Summary
- brighten the name on the about page
- restyle hero section with a sleek gradient

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_686318664504832fa2944e8b65e78d8b