### PR TITLE
Restore hero gradient colors

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -72,7 +72,7 @@ header img {
 /* Hero section */
 .hero {
   /* Sleek gradient background */
-  background: linear-gradient(135deg, #232526 0%, #414345 100%);
+  background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
   background-size: cover;
   background-position: center;
   color: white;


### PR DESCRIPTION
## Summary
- restore hero gradient to use the theme colors instead of black

## Testing
- `bundle install`
- `bundle exec jekyll build`


